### PR TITLE
Remove empty space below footer

### DIFF
--- a/resources/sass/_landing.scss
+++ b/resources/sass/_landing.scss
@@ -27,6 +27,7 @@ p {
 
 .cover {
   background: no-repeat center/cover;
+  min-height: calc(100% - 60px); 
 }
 
 .scroll .hero {


### PR DESCRIPTION
This Pull Request solves the only issue that was left in [this card](https://trello.com/c/vldzUJqi). Specifically, it removes the extra empty space that was shown to users of certain resolution both on mobile and desktop.

Thanks @krkc for the hint!

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/20182642/70378362-103c6080-1928-11ea-81f7-226f503cfb1b.png)


After:
![image](https://user-images.githubusercontent.com/20182642/70378360-00bd1780-1928-11ea-9808-2020d7890b84.png)


**Test plan**
1. Enter 5minutes5vegans.org/ or your local copy of master and see that below the footer there is an extra green space
  a) If you can't see it, open your favorite browser's dev tools and play with the resolution until you see it. My recommended resolution is 1500 px width on 1024 px height.
2) Fetch the PR and serve the website. Notice that the extra space was removed and now the website looks good on all resolutions.
3) Try to view the website in Mobile-View to make sure that no regression was introduced.

**Closing Cards**
Closes https://trello.com/c/vldzUJqi