### PR TITLE
Improve hashtags for stealth and efficiency

### DIFF
--- a/app/Services/TweetRegexService.php
+++ b/app/Services/TweetRegexService.php
@@ -71,7 +71,7 @@ class TweetRegexService {
             $new_body = preg_replace($re, "#$0", $body, 1, $found_vegan);
 
             // Check if error occured or no matches were found for "vegan"
-            if (PREG_NO_ERROR !== preg_last_error() || $found_vegan < 1) {
+            if (PREG_NO_ERROR !== preg_last_error() || $found_vegan == 0) {
                 $new_body = $body . " #vegan";
             }
 


### PR DESCRIPTION
**Description:**
As discussed on Discord, in order to be stealthier and overcome Twitter's spam\low-quality filtering, this Pull Request implements the following logic:

1. Remove the #5m5v hashtag from the tweet
2. Adds a hashtag ("#") to the first occurrence of `/\bvegan\b/i`.
3. If no occurrences of the pattern found, the tweet will be appended with " #vegan"
4. Fallback to the original logic on error

**Test case:**
1. Fetch this branch and regenerate the tweets
2. Click on different tweets and see that the logic above is implemented accurately.
3. Specifically, pay attention to whether more than one occurrence of "vegan" was replaced with "#vegan". Also, verify that tweets that are not containing the word "vegan" are appended with the hashtag "#vegan".
4. Check that there should be no tweet without the hashtag.

**Screenshots and demonstration:**

In the following screenshot pay attention to the following things:
1. The first occurrence of "Vegan" is prefixed with a hashtag
2. Other occurrences aren't prefixed
3. No "#vegan" appended to the end of the tweet

![image](https://user-images.githubusercontent.com/20182642/71484483-4d07c300-2815-11ea-8b07-80cd50c0a8a2.png)

In the following screenshot notice that there were no occurrences of "vegan" and thus no word is prefixed with a hashtag, Hence, "#vegan" is appended to the tweet
![image](https://user-images.githubusercontent.com/20182642/71484554-a2dc6b00-2815-11ea-898b-758c5900aa11.png)


**Closing cards:**
This PR closes the following card: https://trello.com/c/nzWR8hVp/60-improve-hashtag-stealth-and-efficiency