### PR TITLE
Quick lookahead and lookbehind fix for #vegan hashtag

### DIFF
--- a/app/Services/TweetRegexService.php
+++ b/app/Services/TweetRegexService.php
@@ -54,7 +54,7 @@ class TweetRegexService {
         $grammar = new Read('hoa://Library/Regex/Grammar.pp');
         $compiler = Llk::load($grammar);
         $results = [];
-        $re = '/\bvegan\b/i'; // Regex pattern to match for the word "vegan" insensitive case
+        $re = '/(?<= |^)vegan[^\w\d\s]*(?=[ ]|$)/i'; // Regex pattern to match for the word "vegan" insensitive case
 
         foreach ($tweets as $tweet) {
             $icon = $tweet['icon'];


### PR DESCRIPTION
This should fix the issue with some occurrences of the hashtag. 
For example, before this change /r/vegan was replaced by /r/#vegan.

Test case: https://regex101.com/r/gs1HHg/1

