### PR TITLE
Remove blue border from buttons

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -64,6 +64,7 @@ $xx-swirve: 22px;
 
 .swirvy-box {
     @extend .swirvy-box-left, .swirvy-box-right;
+    outline: none;
 }
 
 .col-xs-5ths,


### PR DESCRIPTION
Addresses [this ticket](https://trello.com/c/AON64ZFH/66-remove-blue-border-that-shows-up-in-mobile-when-tapping-on-things).