### PR TITLE
Remove the second timer

### DIFF
--- a/resources/sass/_feed.scss
+++ b/resources/sass/_feed.scss
@@ -75,20 +75,8 @@ $feed-teal: #41b9aa;
 .timer-section-middle {
     display: none;
 
-    @include for-lg-desktop-up {
+    @include for-desktop-up {
         display: block;
-    }
-}
-
-.timer-section-beneath {
-    display:none;
-
-    @include for-tablet-landscape-up {
-        display: block;
-    }
-
-    @include for-lg-desktop-up {
-        display: none;
     }
 }
 

--- a/resources/views/inc/feed-nav.blade.php
+++ b/resources/views/inc/feed-nav.blade.php
@@ -8,6 +8,7 @@
         <div class="timer-display">
             <div class="minutes">05</div>
             <div class="seconds">00</div>
+            <a id="resetLink" href="#"><span><i class="fas fa-undo fa-sm" style="color:red"></i></span></a>
         </div>
     </div>
     <div class="col text-right">
@@ -17,18 +18,6 @@
     </div>
 </nav>
 <div class="timer-section-middle">
-    <div id="minutes-left" class="text-center">
-        @lang('sidebar.minutes-left')
-    </div>
-</div>
-
-
-<div class="col text-center timer-section-beneath">
-    <div class="timer-display">
-        <div class="minutes">05</div>
-        <div class="seconds">00</div>
-        <a id="resetLink" href="#"><span><i class="fas fa-undo fa-sm" style="color:red"></i></span></a>
-    </div>
     <div id="minutes-left" class="text-center">
         @lang('sidebar.minutes-left')
     </div>


### PR DESCRIPTION
This would also remove the need for #50.

Currently there are two timers. One between the logo and the donate button and one below the block. Starting from LG, the first button is visible. This PR just removes the second timer and shows the first starting from 1200px instead of 1596px.