### PR TITLE
Update swiper import to include full bundle

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,7 +8,7 @@ require('./bootstrap')
 window.Vue = require('vue')
 require('vue-resource')
 require('fontawesome-iconpicker')
-import Swiper from 'swiper'
+import Swiper from 'swiper/bundle'
 import Clipboard from 'v-clipboard'
 
 /*********
@@ -104,7 +104,7 @@ $(() => {
             clickable: true,
             renderBullet: function(index, className) {
                 return `
-                <span class="swirvy-box ${classname}">${
+                <span class="swirvy-box ${className}">${
                     index === 0 ? 'resources' : 'feed'
                 }</span>
                 `


### PR DESCRIPTION
https://trello.com/c/Cm4Zlxgb/178-bug-mobile-users-can-no-longer-navigate-away-from-the-twitter-feed

- Update the import to use `swiper/bundle` (reference: https://swiperjs.com/get-started)
- Fix typo in pagination bullet function